### PR TITLE
HEX file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Installation
 [Python](http://www.python.org) (>=2.6) and its serial port extension
 model [pySerial](http://pyserial.sf.net/) are required to run
 stcflash.  Python is most likely pre-installed if you are using a
-mainstream Linux distribution.  Module pySerial, on the other hand,
+mainstream Linux distribution or OS X.  Module pySerial, on the other hand,
 might need to be installed manually.  For example, on Ubuntu, you must
 install package python-serial (or python3-serial for Python 3) to get
 pySerial.  For operating system without a package management system
@@ -57,21 +57,13 @@ Connect to /dev/ttyUSB1 at baudrate 1200
 Detecting target...
 ```
 
-To download program into the target, the compiled code must be in
-binary format (.bin), as it is the only format that stcflash supports.
-If you want to program an Intel HEX file (.ihx or .hex), it needs to
-be converted to binary format first.  On a Linux system, this can be
-done using objcopy or makebin, which comes with the open source MCS-51
-compiler sdcc.
+To download program into the target, the compiled code can be in
+binary format (.bin) or Intel HEX file (.ihx or .hex, **experimental, use at your own risk**). Now stcflash supports both of them.
+
+You can program the .hex file directly using the following command,
 
 ```
-$ objcopy -Iihex -Obinary program.hex program.bin
-```
-
-Then you can program the .bin file using the following command,
-
-```
-$ python stcflash.py program.bin
+$ python stcflash.py program.hex
 Connect to /dev/ttyUSB0 at baudrate 2400
 Detecting target... done
  FOSC: 11.955MHz
@@ -81,6 +73,21 @@ Baudrate: 38400
 Erasing target... done
 Size of the binary: 917
 Programming: #################### done
+```
+
+As for programming an Intel HEX file and converting it to binary format, they can also be done using objcopy or makebin on Linux systems, which comes with the open source MCS-51
+compiler sdcc.
+
+```
+$ objcopy -Iihex -Obinary program.hex program.bin
+```
+
+On OS X, "objcopy" may be called "gobjcopy", and you must install "binutils" before using it by Homebrew or MacPorts. 
+
+Then you can program the .bin file using the following command,
+
+```
+$ python stcflash.py program.bin
 ```
 
 For now, stcflash can program the following series and their low

--- a/stcflash.py
+++ b/stcflash.py
@@ -575,7 +575,7 @@ def hex2bin(fileName):
                 break
 
             dataAddr = int(src[9:13], 16)
-            checksum += (dataAddr>>2) + (dataAddr & 0xFF)
+            checksum += (dataAddr>>8) + (dataAddr & 0xFF)
 
             # Checksum at end
             checksum += int(src[-2:], 16)
@@ -593,7 +593,7 @@ def hex2bin(fileName):
                 break
 
             dataAddr = int(src[9:13], 16)
-            checksum += (dataAddr>>2) + (dataAddr & 0xFF)
+            checksum += (dataAddr>>8) + (dataAddr & 0xFF)
 
             # Checksum at end
             checksum += int(src[-2:], 16)

--- a/stcflash.py
+++ b/stcflash.py
@@ -21,6 +21,7 @@ import logging
 import sys
 import getopt
 import serial
+import os
 
 
 PROTOCOL_STC89 = 89
@@ -496,7 +497,7 @@ def usage():
     port = 'COM3' if sys.platform.startswith('win') else '/dev/ttyUSB0'
     port = '/dev/tty.usbserial' if sys.platform == 'darwin' else port
 
-    print("Usage: %s [OPTION]... [bin file]" % sys.argv[0])
+    print("Usage: %s [OPTION]... [bin/hex file]" % sys.argv[0])
     print("""
   -p, --port       specify serial port (default: %(port)s)
   -l, --lowbaud    specify lower baudrate (default: 2400)
@@ -508,6 +509,116 @@ def usage():
   -h, --help       give this help list
 """ % {'port': port})
   
+# Convert hex to bin format
+def hex2bin(fileName):
+    error = False
+    highAddr = 0
+
+    hexFile = open(fileName, 'rb')
+    binFile = open(fileName+'.bin', 'wb')
+    
+    hexData = hexFile.read()
+    for src in hexData.replace("\r",'').split("\n"):
+        if len(src) < 11 or src[0] != ':': 
+            # Invalid data
+            error = True
+            break
+
+        # Get length of the data
+        dataLen = int(src[1:3], 16)
+        checksum = dataLen
+
+        # Get address of the data
+        dataAddr = int(src[3:7], 16)
+        checksum += (dataAddr>>8) + (dataAddr & 0xFF)
+
+        # Get data type
+        dataType = int(src[7:9], 16)
+        checksum += dataType
+
+        if dataType == 0:      # Data record
+            dst = ''
+            for i in range(0, dataLen):
+                t = int(src[9+2*i:9+2*i+2], 16)
+                checksum += t
+                dst += chr(t)
+
+            # Checksum at end
+            checksum += int(src[-2:], 16)
+
+            if checksum & 0xFF == 0:
+                binFile.seek(highAddr + dataAddr)
+                binFile.write(dst)
+            else:
+                print 'hex2bin ERROR: Wrong checksum!'
+                error = True
+                break
+
+        elif dataType == 1:    # EOF record
+            if dataAddr != 0: 
+                error = True
+                break
+
+            # Checksum at end
+            checksum += int(src[-2:], 16)
+
+            if checksum & 0xFF == 0:
+                break
+            else:
+                print 'hex2bin ERROR: Wrong checksum!'
+                error = True
+                break
+
+        elif dataType == 2:    # Extended segment address record
+            if dataAddr != 0: 
+                error = True
+                break
+
+            dataAddr = int(src[9:13], 16)
+            checksum += (dataAddr>>2) + (dataAddr & 0xFF)
+
+            # Checksum at end
+            checksum += int(src[-2:], 16)
+
+            if checksum & 0xFF == 0:
+                highAddr = dataAddr << 2;
+            else:
+                print 'hex2bin ERROR: Wrong checksum!'
+                error = True
+                break
+
+        elif dataType == 4:    # Extended linear address record
+            if dataAddr != 0:
+                error = True
+                break
+
+            dataAddr = int(src[9:13], 16)
+            checksum += (dataAddr>>2) + (dataAddr & 0xFF)
+
+            # Checksum at end
+            checksum += int(src[-2:], 16)
+
+            if checksum & 0xFF == 0:
+                highAddr = dataAddr << 16;
+            else:
+                print 'hex2bin ERROR: Wrong checksum!'
+                error = True
+                break
+        else:
+            print 'hex2bin ERROR: Wrong datatype!'
+            error = True
+            break
+
+    hexFile.close()
+    binFile.close()
+    if error:
+        return -1
+
+    binFile = open(fileName+'.bin', 'rb')
+    binCode = binFile.read()
+    binFile.close() 
+    return binCode
+
 
 def main():
     port = 'COM3' if sys.platform.startswith('win') else '/dev/ttyUSB0'
@@ -568,8 +679,12 @@ def main():
                         level=loglevel)
 
     if len(args) > 0:
-        with open(args[0], 'rb') as f:
-            code = f.read()
+        if os.path.splitext(args[0])[1] in ('.hex', '.ihx'):
+            code = hex2bin(args[0])
+            if code == -1: sys.exit(2)
+        else:
+            with open(args[0], 'rb') as f:
+                code = f.read()
 
     print("Connect to %s at baudrate %d" % (port, lowbaud))
     with serial.Serial(port=port, 
@@ -582,3 +697,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/stcflash.py
+++ b/stcflash.py
@@ -494,6 +494,7 @@ def program(prog, code):
 
 def usage():
     port = 'COM3' if sys.platform.startswith('win') else '/dev/ttyUSB0'
+    port = '/dev/tty.usbserial' if sys.platform == 'darwin' else port
 
     print("Usage: %s [OPTION]... [bin file]" % sys.argv[0])
     print("""
@@ -510,6 +511,7 @@ def usage():
 
 def main():
     port = 'COM3' if sys.platform.startswith('win') else '/dev/ttyUSB0'
+    port = '/dev/tty.usbserial' if sys.platform == 'darwin' else port
     lowbaud = 2400
     loglevel = logging.CRITICAL
     code = None


### PR DESCRIPTION
In general, the default port in Mac is called ``/dev/tty.usbserial’’. The first commit is just for
convenience.

The second commit is HEX support.